### PR TITLE
FIX: Uncaught ReferenceError: arguments is not defined at max

### DIFF
--- a/src/PHP_CoreFunctions.js
+++ b/src/PHP_CoreFunctions.js
@@ -443,7 +443,7 @@ const ceil = (value) => {
     return Math.ceil(value)
 }
 
-const max = () => {
+const max = (...argv) => {
     //  discuss at: https://locutus.io/php/max/
     // original by: Onno Marsman (https://twitter.com/onnomarsman)
     //  revised by: Onno Marsman (https://twitter.com/onnomarsman)
@@ -466,7 +466,6 @@ const max = () => {
     var retVal
     var i = 0
     var n = 0
-    var argv = arguments
     var argc = argv.length
     var _obj2Array = function (obj) {
       if (Object.prototype.toString.call(obj) === '[object Array]') {


### PR DESCRIPTION
On arrow functions arguments is not defined, original version was a normal function
https://locutus.io/php/math/max/
```js
module.exports = function max () {
```
https://github.com/gamalielmendez/node-fpdf/blob/4eb92899785c0bc36c157bd6e37837f3aa578e36/src/PHP_CoreFunctions.js#L446